### PR TITLE
Admin viewers page fixes

### DIFF
--- a/pages/components/chart.tsx
+++ b/pages/components/chart.tsx
@@ -1,6 +1,7 @@
 import { LineChart } from 'react-chartkick'
 import styles from '../../styles/styles.module.scss';
 import 'chart.js';
+import format from 'date-fns/format'
 
 interface TimedValue {
   time: Date;
@@ -19,7 +20,8 @@ function createGraphDataset(dataArray) {
   const dataValues = {};
   dataArray.forEach(item => {
     const dateObject = new Date(item.time);
-    dataValues[dateObject] = item.value;
+    const dateString = format(dateObject, 'p P');
+    dataValues[dateString] = item.value;
   })
   return dataValues;
 }

--- a/pages/components/chart.tsx
+++ b/pages/components/chart.tsx
@@ -19,8 +19,7 @@ function createGraphDataset(dataArray) {
   const dataValues = {};
   dataArray.forEach(item => {
     const dateObject = new Date(item.time);
-    const dateString = `${dateObject.getFullYear()  }-${  dateObject.getMonth()  }-${  dateObject.getDay()  } ${  dateObject.getHours()  }:${  dateObject.getMinutes()}`;
-    dataValues[dateString] = item.value;
+    dataValues[dateObject] = item.value;
   })
   return dataValues;
 }

--- a/pages/viewer-info.tsx
+++ b/pages/viewer-info.tsx
@@ -120,7 +120,7 @@ export default function ViewersOverTime() {
         />
       </Row>
       <Chart title="Viewers" data={viewerInfo} color="#2087E2" unit="" />
-      <Table dataSource={clients} columns={columns} rowKey={(row) => row.userAgent} />
+      <Table dataSource={clients} columns={columns} rowKey={(row) => row.clientID} />
     </div>
   );
 }


### PR DESCRIPTION
1. Use the `clientID` as the unique key in the viewers table to hopefully fix the weird duplicate rows in the viewers table.
2. Remove the bad date formatting in the graph component and use the raw date object instead to fix the off-by-one month formatting.