### PR TITLE
Admin page for managing access tokens

### DIFF
--- a/pages/access-tokens.tsx
+++ b/pages/access-tokens.tsx
@@ -178,7 +178,7 @@ function NewTokenModal(props) {
         props.onOk(name, selectedScopes)
     }
 
-    const [name, setName] = useState([]);
+    const [name, setName] = useState('');
 
     return (
         <Modal title="Create New Access token" visible={props.visible} onOk={saveToken} onCancel={props.onCancel}>

--- a/pages/access-tokens.tsx
+++ b/pages/access-tokens.tsx
@@ -1,0 +1,193 @@
+import React, { useState, useEffect } from "react";
+import { Table, Tag, Space, Button, Modal, Checkbox, Input, Typography } from 'antd';
+import { DeleteOutlined, EyeTwoTone, EyeInvisibleOutlined } from '@ant-design/icons';
+const { Title, Paragraph, Text } = Typography;
+
+import format from 'date-fns/format'
+
+import {
+    fetchData,
+    ACCESS_TOKENS,
+    DELETE_ACCESS_TOKEN,
+    CREATE_ACCESS_TOKEN,
+} from "../utils/apis";
+
+export default function Logs() {
+    const columns = [
+        {
+            title: '',
+            key: 'delete',
+            render: (text, record) => (
+                <Space size="middle">
+                    <Button onClick={() => handleDeleteToken(record.token)} icon={<DeleteOutlined />} />
+                </Space>
+            )
+        },
+        {
+            title: 'Name',
+            dataIndex: 'name',
+            key: 'name',
+        },
+        {
+            title: 'Token',
+            dataIndex: 'token',
+            key: 'token',
+            render: (text, record) => (
+               <Input.Password size="small" bordered={false} value={text}/>
+            )
+        },
+        {
+            title: 'Scopes',
+            dataIndex: 'scopes',
+            key: 'scopes',
+            render: scopes => (
+                <>
+                    {scopes.map(scope => {
+                        const color = 'purple';
+
+                        return (
+                            <Tag color={color} key={scope}>
+                                {convertScopeStringToRenderString(scope)}
+                            </Tag>
+                        );
+                    })}
+                </>
+            ),
+        },
+        {
+            title: 'Last Used',
+            dataIndex: 'lastUsed',
+            key: 'lastUsed',
+            render: (timestamp) => {
+                const dateObject = new Date(timestamp);
+                return format(dateObject, 'P p');
+            },
+        },
+    ];
+
+    const [tokens, setTokens] = useState([]);
+
+    const getAccessTokens = async () => {
+        try {
+            const result = await fetchData(ACCESS_TOKENS);
+            setTokens(result);
+        } catch (error) {
+            handleError(error);
+        }
+    };
+
+    useEffect(() => {
+        getAccessTokens();
+
+        // returned function will be called on component unmount
+        return () => {
+        };
+    }, []);
+
+    async function handleDeleteToken(token) {
+        try {
+            const result = await fetchData(DELETE_ACCESS_TOKEN, { method: 'POST', data: { token: token } });
+            getAccessTokens();
+        } catch (error) {
+            handleError(error);
+        }
+    }
+
+    async function handleSaveToken(name: string, scopes: string[]) {
+        try {
+            const result = await fetchData(CREATE_ACCESS_TOKEN, { method: 'POST', data: { name: name, scopes: scopes } });
+            getAccessTokens();
+        } catch (error) {
+            handleError(error);
+        }
+    }
+
+    function handleError(error) {
+        console.error("error", error);
+        alert(error);
+    }
+
+    const [isTokenModalVisible, setIsTokenModalVisible] = useState(false);
+
+    const showCreateTokenModal = () => {
+        setIsTokenModalVisible(true);
+    };
+
+    const handleTokenModalSaveButton = (name, scopes) => {
+        setIsTokenModalVisible(false);
+        handleSaveToken(name, scopes);
+    };
+
+    const handleTokenModalCancel = () => {
+        setIsTokenModalVisible(false);
+    };
+
+
+    return (
+        <div>
+            <Title>Access Tokens</Title>
+            <Paragraph>
+                Access tokens are used to allow external, 3rd party tools to perform specific actions on your Owncast server.
+                They should be kept secure and never included in client code, instead they should be kept on a server that you control.
+            </Paragraph>
+            <Paragraph>
+                Read more about how to use these tokens at _some documentation here_.
+            </Paragraph>
+
+            <Table rowKey="token" columns={columns} dataSource={tokens} pagination={false} />
+            <Button onClick={showCreateTokenModal}>Create Access Token</Button>
+            <NewTokenModal visible={isTokenModalVisible} onOk={handleTokenModalSaveButton} onCancel={handleTokenModalCancel} />
+        </div>
+    );
+}
+
+const scopeMapping = {
+    'CAN_SEND_SYSTEM_MESSAGES': 'system chat',
+    'CAN_SEND_MESSAGES': 'user chat',
+};
+
+function convertScopeStringToRenderString(scope) {
+    if (!scopeMapping[scope]) {
+        return "unknown";
+    }
+
+    return scopeMapping[scope].toUpperCase();
+}
+
+function NewTokenModal(props) {
+    var selectedScopes = [];
+
+    const scopes = [
+        {
+            value: 'CAN_SEND_SYSTEM_MESSAGES',
+            label: 'Can send system chat messages',
+            description: 'Can send chat messages as the offical system user.'
+        },
+        {
+            value: 'CAN_SEND_MESSAGES',
+            label: 'Can send user chat messages',
+            description: 'Can send chat messages as any user name.'
+        },
+    ]
+
+    function onChange(checkedValues) {
+        selectedScopes = checkedValues
+    }
+
+    function saveToken() {
+        props.onOk(name, selectedScopes)
+    }
+
+    const [name, setName] = useState([]);
+
+    return (
+        <Modal title="Create New Access token" visible={props.visible} onOk={saveToken} onCancel={props.onCancel}>
+            <p><Input value={name} placeholder="Access token name/description" onChange={(input) => setName(input.currentTarget.value)} /></p>
+
+            <p>
+                Select the permissions this access token will have.  It cannot be edited after it's created.
+            </p>
+            <Checkbox.Group options={scopes} onChange={onChange} />
+        </Modal>
+    )
+}

--- a/pages/access-tokens.tsx
+++ b/pages/access-tokens.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Table, Tag, Space, Button, Modal, Checkbox, Input, Typography } from 'antd';
+import { Table, Tag, Space, Button, Modal, Checkbox, Input, Typography, Tooltip } from 'antd';
 import { DeleteOutlined, EyeTwoTone, EyeInvisibleOutlined } from '@ant-design/icons';
 const { Title, Paragraph, Text } = Typography;
 
@@ -12,34 +12,34 @@ import {
     CREATE_ACCESS_TOKEN,
 } from "../utils/apis";
 
-const scopeMapping = {
-    'CAN_SEND_SYSTEM_MESSAGES': 'system chat',
-    'CAN_SEND_MESSAGES': 'user chat',
+const availableScopes = {
+    'CAN_SEND_SYSTEM_MESSAGES': { name: 'System messages', description: 'You can send official messages on behalf of the system', color: 'purple' },
+    'CAN_SEND_MESSAGES': { name: 'User chat messages', description: 'You can send messages on behalf of a username', color: 'green' },
 };
 
-function convertScopeStringToRenderString(scope) {
-    if (!scope || !scopeMapping[scope]) {
-        return "unknown";
+function convertScopeStringToTag(scopeString) {
+    if (!scopeString || !availableScopes[scopeString]) {
+        return null;
     }
 
-    return scopeMapping[scope].toUpperCase();
+    const scope = availableScopes[scopeString];
+
+    return (
+        <Tooltip key={scopeString} title={scope.description}>
+            <Tag color={scope.color} >
+                {scope.name}
+            </Tag>
+        </Tooltip>
+    );
 }
 
 function NewTokenModal(props) {
     var selectedScopes = [];
 
-    const scopes = [
-        {
-            value: 'CAN_SEND_SYSTEM_MESSAGES',
-            label: 'Can send system chat messages',
-            description: 'Can send chat messages as the offical system user.'
-        },
-        {
-            value: 'CAN_SEND_MESSAGES',
-            label: 'Can send user chat messages',
-            description: 'Can send chat messages as any user name.'
-        },
-    ]
+
+    const scopes = Object.keys(availableScopes).map(function (key) {
+        return { value: key, label: availableScopes[key].description }
+    });
 
     function onChange(checkedValues) {
         selectedScopes = checkedValues
@@ -97,13 +97,7 @@ export default function AccessTokens() {
             render: scopes => (
                 <>
                     {scopes.map(scope => {
-                        const color = 'purple';
-
-                        return (
-                            <Tag color={color} key={scope}>
-                                {convertScopeStringToRenderString(scope)}
-                            </Tag>
-                        );
+                        return convertScopeStringToTag(scope);
                     })}
                 </>
             ),

--- a/pages/access-tokens.tsx
+++ b/pages/access-tokens.tsx
@@ -12,7 +12,61 @@ import {
     CREATE_ACCESS_TOKEN,
 } from "../utils/apis";
 
-export default function Logs() {
+const scopeMapping = {
+    'CAN_SEND_SYSTEM_MESSAGES': 'system chat',
+    'CAN_SEND_MESSAGES': 'user chat',
+};
+
+function convertScopeStringToRenderString(scope) {
+    if (!scope || !scopeMapping[scope]) {
+        return "unknown";
+    }
+
+    return scopeMapping[scope].toUpperCase();
+}
+
+function NewTokenModal(props) {
+    var selectedScopes = [];
+
+    const scopes = [
+        {
+            value: 'CAN_SEND_SYSTEM_MESSAGES',
+            label: 'Can send system chat messages',
+            description: 'Can send chat messages as the offical system user.'
+        },
+        {
+            value: 'CAN_SEND_MESSAGES',
+            label: 'Can send user chat messages',
+            description: 'Can send chat messages as any user name.'
+        },
+    ]
+
+    function onChange(checkedValues) {
+        selectedScopes = checkedValues
+    }
+
+    function saveToken() {
+        props.onOk(name, selectedScopes)
+    }
+
+    const [name, setName] = useState('');
+
+    return (
+        <Modal title="Create New Access token" visible={props.visible} onOk={saveToken} onCancel={props.onCancel}>
+            <p><Input value={name} placeholder="Access token name/description" onChange={(input) => setName(input.currentTarget.value)} /></p>
+
+            <p>
+                Select the permissions this access token will have.  It cannot be edited after it's created.
+            </p>
+            <Checkbox.Group options={scopes} onChange={onChange} />
+        </Modal>
+    )
+}
+
+export default function AccessTokens() {
+    const [tokens, setTokens] = useState([]);
+    const [isTokenModalVisible, setIsTokenModalVisible] = useState(false);
+
     const columns = [
         {
             title: '',
@@ -65,8 +119,6 @@ export default function Logs() {
         },
     ];
 
-    const [tokens, setTokens] = useState([]);
-
     const getAccessTokens = async () => {
         try {
             const result = await fetchData(ACCESS_TOKENS);
@@ -78,10 +130,6 @@ export default function Logs() {
 
     useEffect(() => {
         getAccessTokens();
-
-        // returned function will be called on component unmount
-        return () => {
-        };
     }, []);
 
     async function handleDeleteToken(token) {
@@ -107,8 +155,6 @@ export default function Logs() {
         alert(error);
     }
 
-    const [isTokenModalVisible, setIsTokenModalVisible] = useState(false);
-
     const showCreateTokenModal = () => {
         setIsTokenModalVisible(true);
     };
@@ -121,7 +167,6 @@ export default function Logs() {
     const handleTokenModalCancel = () => {
         setIsTokenModalVisible(false);
     };
-
 
     return (
         <div>
@@ -139,55 +184,4 @@ export default function Logs() {
             <NewTokenModal visible={isTokenModalVisible} onOk={handleTokenModalSaveButton} onCancel={handleTokenModalCancel} />
         </div>
     );
-}
-
-const scopeMapping = {
-    'CAN_SEND_SYSTEM_MESSAGES': 'system chat',
-    'CAN_SEND_MESSAGES': 'user chat',
-};
-
-function convertScopeStringToRenderString(scope) {
-    if (!scopeMapping[scope]) {
-        return "unknown";
-    }
-
-    return scopeMapping[scope].toUpperCase();
-}
-
-function NewTokenModal(props) {
-    var selectedScopes = [];
-
-    const scopes = [
-        {
-            value: 'CAN_SEND_SYSTEM_MESSAGES',
-            label: 'Can send system chat messages',
-            description: 'Can send chat messages as the offical system user.'
-        },
-        {
-            value: 'CAN_SEND_MESSAGES',
-            label: 'Can send user chat messages',
-            description: 'Can send chat messages as any user name.'
-        },
-    ]
-
-    function onChange(checkedValues) {
-        selectedScopes = checkedValues
-    }
-
-    function saveToken() {
-        props.onOk(name, selectedScopes)
-    }
-
-    const [name, setName] = useState('');
-
-    return (
-        <Modal title="Create New Access token" visible={props.visible} onOk={saveToken} onCancel={props.onCancel}>
-            <p><Input value={name} placeholder="Access token name/description" onChange={(input) => setName(input.currentTarget.value)} /></p>
-
-            <p>
-                Select the permissions this access token will have.  It cannot be edited after it's created.
-            </p>
-            <Checkbox.Group options={scopes} onChange={onChange} />
-        </Modal>
-    )
 }

--- a/pages/access-tokens.tsx
+++ b/pages/access-tokens.tsx
@@ -133,7 +133,7 @@ export default function AccessTokens() {
 
     useEffect(() => {
         getAccessTokens();
-    }, [tokens]);
+    }, []);
 
     async function handleDeleteToken(token) {
         try {
@@ -147,8 +147,7 @@ export default function AccessTokens() {
     async function handleSaveToken(name: string, scopes: string[]) {
         try {
             const newToken = await fetchData(CREATE_ACCESS_TOKEN, { method: 'POST', data: { name: name, scopes: scopes } });
-            tokens.push(newToken);
-            setTokens(tokens);
+            setTokens(tokens.concat(newToken));
         } catch (error) {
             handleError(error);
         }

--- a/pages/access-tokens.tsx
+++ b/pages/access-tokens.tsx
@@ -112,8 +112,11 @@ export default function AccessTokens() {
             title: 'Last Used',
             dataIndex: 'lastUsed',
             key: 'lastUsed',
-            render: (timestamp) => {
-                const dateObject = new Date(timestamp);
+            render: (lastUsed) => {
+                if (!lastUsed) {
+                    return 'Never';
+                }
+                const dateObject = new Date(lastUsed);
                 return format(dateObject, 'P p');
             },
         },
@@ -130,7 +133,7 @@ export default function AccessTokens() {
 
     useEffect(() => {
         getAccessTokens();
-    }, []);
+    }, [tokens]);
 
     async function handleDeleteToken(token) {
         try {
@@ -143,8 +146,9 @@ export default function AccessTokens() {
 
     async function handleSaveToken(name: string, scopes: string[]) {
         try {
-            const result = await fetchData(CREATE_ACCESS_TOKEN, { method: 'POST', data: { name: name, scopes: scopes } });
-            getAccessTokens();
+            const newToken = await fetchData(CREATE_ACCESS_TOKEN, { method: 'POST', data: { name: name, scopes: scopes } });
+            tokens.push(newToken);
+            setTokens(tokens);
         } catch (error) {
             handleError(error);
         }

--- a/utils/apis.ts
+++ b/utils/apis.ts
@@ -40,6 +40,14 @@ export const CHAT_HISTORY = `${API_LOCATION}chat/messages`;
 // Get chat history
 export const UPDATE_CHAT_MESSGAE_VIZ = `${NEXT_PUBLIC_API_HOST}api/admin/chat/updatemessagevisibility`;
 
+// Get all access tokens
+export const ACCESS_TOKENS = `${API_LOCATION}accesstokens`;
+
+// Delete a single access token
+export const DELETE_ACCESS_TOKEN = `${API_LOCATION}deleteaccesstoken`;
+
+// Create a new access token
+export const CREATE_ACCESS_TOKEN = `${API_LOCATION}createaccesstoken`;
 
 const GITHUB_RELEASE_URL = "https://api.github.com/repos/owncast/owncast/releases/latest";
 


### PR DESCRIPTION
This page is for 3rd party integration development and not a page we want to surface on the menu yet.  It needs to be run against the in-development 3rd party integrations branch for it to work.

It works but needs to be polished before we surface it to regular people.  Going to keep a `external-integrations` branch just like we do for core.

1. Errors should be surfaced to the users.
2. We should confirm access token delete actions.
3. The "Create access token" modal should disable the save button until the name is filled out and at least one scope is selected.

![image](https://user-images.githubusercontent.com/414923/103606994-bca29a80-4ecc-11eb-9dc4-02c0a3fcd058.png)

![image](https://user-images.githubusercontent.com/414923/103607050-e2c83a80-4ecc-11eb-87fc-d80163e93d8e.png)
