### PR TITLE
React-codemod to refactor React imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,47 +4,49 @@ module.exports = {
     es2021: true,
   },
   extends: [
-    "plugin:react/recommended",
-    "airbnb",
-    "prettier",
-    "prettier/@typescript-eslint",
-    "prettier/react",
+    'plugin:react/recommended',
+    'airbnb',
+    'prettier',
+    'prettier/@typescript-eslint',
+    'prettier/react',
   ],
-  parser: "@typescript-eslint/parser",
+  parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaFeatures: {
       jsx: true,
     },
     ecmaVersion: 12,
-    sourceType: "module",
+    sourceType: 'module',
   },
-  plugins: ["react", "@typescript-eslint"],
+  plugins: ['react', '@typescript-eslint'],
   rules: {
-    "react/react-in-jsx-scope": "off",
-    "react/jsx-filename-extension": [1, { extensions: [".js", ".jsx", ".tsx"] }],
-    "react/jsx-props-no-spreading": "off",
-    
+    'react/react-in-jsx-scope': 'off',
+    'react/jsx-filename-extension': [1, { extensions: ['.js', '.jsx', '.tsx'] }],
+    'react/jsx-props-no-spreading': 'off',
+
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': 'error',
-    
+
     'no-use-before-define': [0],
     '@typescript-eslint/no-use-before-define': [1],
-    
-    "import/extensions": [
-      "error",
-      "ignorePackages",
+
+    'import/extensions': [
+      'error',
+      'ignorePackages',
       {
-        "js": "never",
-        "jsx": "never",
-        "ts": "never",
-        "tsx": "never"
+        'js': 'never',
+        'jsx': 'never',
+        'ts': 'never',
+        'tsx': 'never'
       }
-   ]
+    ],
+    quotes: ['error', 'single', { 'allowTemplateLiterals': true }],
+    'jsx-quotes': ['error', 'prefer-double']
   },
   settings: {
-    "import/resolver": {
-      "node": {
-        "extensions": [".js", ".jsx", ".ts", ".tsx"]
+    'import/resolver': {
+      'node': {
+        'extensions': ['.js', '.jsx', '.ts', '.tsx']
       }
     }
   },

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  basePath: "/admin",
+  basePath: '/admin',
   trailingSlash: true,
 };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build && next export",
-    "start": "next start"
+    "start": "next start",
+    "lint": "tsc --noEmit && eslint -c .eslintrc.js './**/*.{js,ts,tsx}'"
   },
   "dependencies": {
     "@ant-design/icons": "^4.2.2",

--- a/pages/broadcast-info.tsx
+++ b/pages/broadcast-info.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { ServerStatusContext } from '../utils/server-status-context';
 
 

--- a/pages/chat.tsx
+++ b/pages/chat.tsx
@@ -1,14 +1,14 @@
-import React, { useState, useEffect } from "react";
-import { Table, Typography, Tooltip, Button } from "antd";
-import { CheckCircleFilled, ExclamationCircleFilled } from "@ant-design/icons";
+import { useState, useEffect } from 'react';
+import { Table, Typography, Tooltip, Button } from 'antd';
+import { CheckCircleFilled, ExclamationCircleFilled } from '@ant-design/icons';
 import classNames from 'classnames';
 import { ColumnsType } from 'antd/es/table';
 import format from 'date-fns/format'
 
 import { CHAT_HISTORY, fetchData, FETCH_INTERVAL, UPDATE_CHAT_MESSGAE_VIZ } from '../utils/apis';
 import { MessageType } from '../types/chat';
-import { isEmptyObject } from "../utils/format";
-import MessageVisiblityToggle from "./components/message-visiblity-toggle";
+import { isEmptyObject } from '../utils/format';
+import MessageVisiblityToggle from './components/message-visiblity-toggle';
 
 const { Title } = Typography;
 

--- a/pages/chat.tsx
+++ b/pages/chat.tsx
@@ -54,7 +54,7 @@ export default function Chat() {
         setMessages(result);
       }
     } catch (error) {
-      console.log("==== error", error);
+      console.log('==== error', error);
     }
   };
 
@@ -98,7 +98,7 @@ export default function Chat() {
       },
     });
 
-    if (result.success && result.message === "changed") {
+    if (result.success && result.message === 'changed') {
       setBulkOutcome(<CheckCircleFilled />);
       resetBulkOutcome();
 

--- a/pages/chat.tsx
+++ b/pages/chat.tsx
@@ -1,13 +1,13 @@
-import React, { useState, useEffect } from "react";
-import { Table, Typography, Tooltip, Button } from "antd";
-import { CheckCircleFilled, ExclamationCircleFilled, StopOutlined } from "@ant-design/icons";
+import { useState, useEffect } from 'react';
+import { Table, Typography, Tooltip, Button } from 'antd';
+import { CheckCircleFilled, ExclamationCircleFilled, StopOutlined } from '@ant-design/icons';
 import classNames from 'classnames';
 import { ColumnsType } from 'antd/es/table';
 import format from 'date-fns/format'
 
-import { CHAT_HISTORY, fetchData, FETCH_INTERVAL, UPDATE_CHAT_MESSGAE_VIZ } from "../utils/apis";
+import { CHAT_HISTORY, fetchData, FETCH_INTERVAL, UPDATE_CHAT_MESSGAE_VIZ } from '../utils/apis';
 import { MessageType } from '../types/chat';
-import { isEmptyObject } from "../utils/format";
+import { isEmptyObject } from '../utils/format';
 
 const { Title } = Typography;
 
@@ -72,7 +72,7 @@ export default function Chat() {
   }, []);
 
   const nameFilters = createUserNameFilters(messages);
-  
+
   const rowSelection = {
     selectedRowKeys,
     onChange: (selectedKeys: string[]) => {
@@ -149,7 +149,7 @@ export default function Chat() {
       filters: nameFilters,
       onFilter: (value, record) => record.author === value,
       sorter: (a, b) => a.author.localeCompare(b.author),
-      sortDirections: ['ascend', 'descend'],  
+      sortDirections: ['ascend', 'descend'],
       ellipsis: true,
       render: author => (
         <Tooltip placement="topLeft" title={author}>
@@ -188,7 +188,7 @@ export default function Chat() {
     'bulk-editor': true,
     active: selectedRowKeys.length,
   });
-  
+
   return (
     <div className="chat-messages">
       <Title level={2}>Chat Messages</Title>
@@ -224,7 +224,7 @@ export default function Chat() {
       <Table
         size="small"
         className="messages-table"
-        pagination={{ pageSize: 100 }} 
+        pagination={{ pageSize: 100 }}
         scroll={{ y: 540 }}
         rowClassName={record => !record.visible ? 'hidden' : ''}
         dataSource={messages}
@@ -234,5 +234,3 @@ export default function Chat() {
       />
   </div>)
 }
-
-

--- a/pages/components/key-value-table.tsx
+++ b/pages/components/key-value-table.tsx
@@ -5,14 +5,14 @@ const { Title } = Typography;
 export default function KeyValueTable({ title, data }: KeyValueTableProps) {
   const columns = [
     {
-      title: "Name",
-      dataIndex: "name",
-      key: "name",
+      title: 'Name',
+      dataIndex: 'name',
+      key: 'name',
     },
     {
-      title: "Value",
-      dataIndex: "value",
-      key: "value",
+      title: 'Value',
+      dataIndex: 'value',
+      key: 'value',
     },
   ];
 

--- a/pages/components/key-value-table.tsx
+++ b/pages/components/key-value-table.tsx
@@ -1,4 +1,4 @@
-import { Table, Typography } from "antd";
+import { Table, Typography } from 'antd';
 
 const { Title } = Typography;
 
@@ -25,6 +25,6 @@ export default function KeyValueTable({ title, data }: KeyValueTableProps) {
 }
 
 interface KeyValueTableProps {
-  title: string, 
+  title: string,
   data: any,
 };

--- a/pages/components/log-table.tsx
+++ b/pages/components/log-table.tsx
@@ -1,7 +1,6 @@
-import React from "react";
-import { Table, Tag, Typography } from "antd";
-import Linkify from "react-linkify";
-import { SortOrder } from "antd/lib/table/interface";
+import { Table, Tag, Typography } from 'antd';
+import Linkify from 'react-linkify';
+import { SortOrder } from 'antd/lib/table/interface';
 import format from 'date-fns/format'
 
 const { Title } = Typography;
@@ -88,4 +87,3 @@ export default function LogTable({ logs, pageSize }: Props) {
     </div>
   );
 }
-

--- a/pages/components/log-table.tsx
+++ b/pages/components/log-table.tsx
@@ -8,10 +8,10 @@ const { Title } = Typography;
 function renderColumnLevel(text, entry) {
   let color = 'black';
 
-  if (entry.level === "warning") {
-    color = "orange";
+  if (entry.level === 'warning') {
+    color = 'orange';
   } else if (entry.level === 'error') {
-    color = "red";
+    color = 'red';
   }
 
   return <Tag color={color}>{text}</Tag>;
@@ -34,42 +34,42 @@ export default function LogTable({ logs, pageSize }: Props) {
   }
   const columns = [
     {
-      title: "Level",
-      dataIndex: "level",
-      key: "level",
+      title: 'Level',
+      dataIndex: 'level',
+      key: 'level',
       filters: [
         {
-          text: "Info",
-          value: "info",
+          text: 'Info',
+          value: 'info',
         },
         {
-          text: "Warning",
-          value: "warning",
+          text: 'Warning',
+          value: 'warning',
         },
         {
-          text: "Error",
-          value: "Error",
+          text: 'Error',
+          value: 'Error',
         },
       ],
       onFilter: (level, row) => row.level.indexOf(level) === 0,
       render: renderColumnLevel,
     },
     {
-      title: "Timestamp",
-      dataIndex: "time",
-      key: "time",
+      title: 'Timestamp',
+      dataIndex: 'time',
+      key: 'time',
       render: (timestamp) => {
         const dateObject = new Date(timestamp);
         return format(dateObject, 'p P');
       },
       sorter: (a, b) => new Date(a.time).getTime() - new Date(b.time).getTime(),
-      sortDirections: ["descend", "ascend"] as SortOrder[],
-      defaultSortOrder: "descend" as SortOrder,
+      sortDirections: ['descend', 'ascend'] as SortOrder[],
+      defaultSortOrder: 'descend' as SortOrder,
     },
     {
-      title: "Message",
-      dataIndex: "message",
-      key: "message",
+      title: 'Message',
+      dataIndex: 'message',
+      key: 'message',
       render: renderMessage,
     },
   ];

--- a/pages/components/logo.tsx
+++ b/pages/components/logo.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import adminStyles from '../../styles/styles.module.scss';
 
 export default function Logo() {

--- a/pages/components/main-layout.tsx
+++ b/pages/components/main-layout.tsx
@@ -39,15 +39,15 @@ export default function MainLayout(props) {
   const { Header, Footer, Content, Sider } = Layout;
   const { SubMenu } = Menu;
 
-  const streamDurationString = online ? parseSecondsToDurationString(differenceInSeconds(new Date(), new Date(broadcaster.time))) : "";
+  const streamDurationString = online ? parseSecondsToDurationString(differenceInSeconds(new Date(), new Date(broadcaster.time))) : '';
 
   const content = (
     <div>
-     <img src="/thumbnail.jpg" width="200px" />
+     <img src="/thumbnail.jpg" alt="thumbnail" width="200px" />
     </div>
   );
   const statusIcon = online ? <PlayCircleFilled /> : <MinusSquareFilled />;
-  const statusMessage = online ? `Online ${streamDurationString}` : "Offline";
+  const statusMessage = online ? `Online ${streamDurationString}` : 'Offline';
 
   const [upgradeVersion, setUpgradeVersion] = useState(null);
   const checkForUpgrade = async () => {
@@ -55,7 +55,7 @@ export default function MainLayout(props) {
       const result = await upgradeVersionAvailable(versionNumber);
       setUpgradeVersion(result);
     } catch (error) {
-      console.log("==== error", error);
+      console.log('==== error', error);
     }
   };
 
@@ -67,7 +67,7 @@ export default function MainLayout(props) {
   });
 
   const appClass = classNames({
-    "owncast-layout": true,
+    'owncast-layout': true,
     [adminStyles.online]: online,
   });
 
@@ -87,8 +87,8 @@ export default function MainLayout(props) {
       >
         <Menu
           theme="dark"
-          defaultSelectedKeys={[route.substring(1) || "home"]}
-          defaultOpenKeys={["current-stream-menu", "utilities-menu", "configuration"]}
+          defaultSelectedKeys={[route.substring(1) || 'home']}
+          defaultOpenKeys={['current-stream-menu', 'utilities-menu', 'configuration']}
           mode="inline"
         >
           <h1 className={adminStyles.owncastTitleContainer}>
@@ -146,7 +146,7 @@ export default function MainLayout(props) {
             </Menu.Item>
             <Menu.Item key="upgrade" style={{ display: upgradeMenuItemStyle }}>
               <Link href="/upgrade">
-                <a>Upgrade to v{upgradeVersionString}</a>
+                {`Upgrade to v${upgradeVersionString}`}
               </Link>
             </Menu.Item>
           </SubMenu>
@@ -171,7 +171,7 @@ export default function MainLayout(props) {
         </Header>
         <Content className={adminStyles.contentMain}>{children}</Content>
 
-        <Footer style={{ textAlign: "center" }}>
+        <Footer style={{ textAlign: 'center' }}>
           <a href="https://owncast.online/">About Owncast v{versionNumber}</a>
         </Footer>
       </Layout>

--- a/pages/components/main-layout.tsx
+++ b/pages/components/main-layout.tsx
@@ -1,8 +1,8 @@
-import React, { useContext, useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import Link from 'next/link';
 import Head from 'next/head'
-import { differenceInSeconds } from "date-fns";
+import { differenceInSeconds } from 'date-fns';
 import { useRouter } from 'next/router';
 import { Layout, Menu, Popover } from 'antd';
 
@@ -17,7 +17,7 @@ import {
   MessageOutlined
 } from '@ant-design/icons';
 import classNames from 'classnames';
-import { upgradeVersionAvailable } from "../../utils/apis";
+import { upgradeVersionAvailable } from '../../utils/apis';
 import { parseSecondsToDurationString } from '../../utils/format'
 
 import OwncastLogo from './logo';
@@ -80,7 +80,7 @@ export default function MainLayout(props) {
         <title>Owncast Admin</title>
         <link rel="icon" type="image/png" sizes="32x32" href="/img/favicon/favicon-32x32.png"/>
       </Head>
-      
+
       <Sider
         width={240}
         className={adminStyles.sideNav}
@@ -116,7 +116,7 @@ export default function MainLayout(props) {
           >
             <Link href="/chat">Chat</Link>
           </Menu.Item>
-          
+
           <SubMenu
             key="configuration"
             title="Configuration"

--- a/pages/components/message-visiblity-toggle.tsx
+++ b/pages/components/message-visiblity-toggle.tsx
@@ -1,11 +1,11 @@
 // Custom component for AntDesign Button that makes an api call, then displays a confirmation icon upon 
-import React, { useState, useEffect } from "react";
-import { Button, Tooltip } from "antd";
-import { EyeOutlined, EyeInvisibleOutlined, CheckCircleFilled, ExclamationCircleFilled } from "@ant-design/icons";
-import { fetchData, UPDATE_CHAT_MESSGAE_VIZ } from "../../utils/apis";
+import { useState, useEffect } from 'react';
+import { Button, Tooltip } from 'antd';
+import { EyeOutlined, EyeInvisibleOutlined, CheckCircleFilled, ExclamationCircleFilled } from '@ant-design/icons';
+import { fetchData, UPDATE_CHAT_MESSGAE_VIZ } from '../../utils/apis';
 import { MessageType } from '../../types/chat';
-import { OUTCOME_TIMEOUT } from "../chat";
-import { isEmptyObject } from "../../utils/format";
+import { OUTCOME_TIMEOUT } from '../chat';
+import { isEmptyObject } from '../../utils/format';
 
 interface MessageToggleProps {
   isVisible: boolean;
@@ -47,7 +47,7 @@ export default function MessageVisiblityToggle({ isVisible, message, setMessage 
       },
     });
 
-    if (result.success && result.message === "changed") {
+    if (result.success && result.message === 'changed') {
       setMessage({ ...message, visible: !isVisible });
       setOutcome(1);
     } else {

--- a/pages/components/statistic.tsx
+++ b/pages/components/statistic.tsx
@@ -1,9 +1,9 @@
-import { Typography, Statistic, Card, Progress} from "antd";
+import { Typography, Statistic, Card, Progress} from 'antd';
 
 const { Text } = Typography;
 
 interface StatisticItemProps {
-  title?: string, 
+  title?: string,
   value?: any,
   prefix?: JSX.Element,
   color?: string,
@@ -12,7 +12,7 @@ interface StatisticItemProps {
   formatter?: any,
 };
 const defaultProps = {
-  title: '', 
+  title: '',
   value: 0,
   prefix: null,
   color: '',

--- a/pages/hardware-info.tsx
+++ b/pages/hardware-info.tsx
@@ -15,7 +15,7 @@ export default function HardwareInfo() {
     cpu: Array<TimedValue>(),
     memory: Array<TimedValue>(),
     disk: Array<TimedValue>(),
-    message: "",
+    message: '',
   });
 
   const getHardwareStatus = async () => {
@@ -53,18 +53,18 @@ export default function HardwareInfo() {
 
 const series = [
   {
-    name: "CPU",
-    color: "#B63FFF",
+    name: 'CPU',
+    color: '#B63FFF',
     data: hardwareStatus.cpu,
   },
   {
-    name: "Memory",
-    color: "#2087E2",
+    name: 'Memory',
+    color: '#2087E2',
     data: hardwareStatus.memory,
   },
   {
-    name: "Disk",
-    color: "#FF7700",
+    name: 'Disk',
+    color: '#FF7700',
     data: hardwareStatus.disk,
   },
 ];

--- a/pages/hardware-info.tsx
+++ b/pages/hardware-info.tsx
@@ -1,9 +1,9 @@
-import { BulbOutlined, LaptopOutlined, SaveOutlined } from "@ant-design/icons";
-import { Row } from "antd";
-import React, { useEffect, useState } from 'react';
+import { BulbOutlined, LaptopOutlined, SaveOutlined } from '@ant-design/icons';
+import { Row } from 'antd';
+import { useEffect, useState } from 'react';
 import { fetchData, FETCH_INTERVAL, HARDWARE_STATS } from '../utils/apis';
 import Chart from './components/chart';
-import StatisticItem from "./components/statistic";
+import StatisticItem from './components/statistic';
 
 interface TimedValue {
   time: Date,
@@ -27,20 +27,20 @@ export default function HardwareInfo() {
       setHardwareStatus({ ...hardwareStatus, message: error.message });
     }
   };
-  
+
   useEffect(() => {
     let getStatusIntervalId = null;
 
     getHardwareStatus();
     getStatusIntervalId = setInterval(getHardwareStatus, FETCH_INTERVAL); // runs every 1 min.
-  
-    // returned function will be called on component unmount 
+
+    // returned function will be called on component unmount
     return () => {
       clearInterval(getStatusIntervalId);
     }
   }, []);
 
- 
+
   if (!hardwareStatus.cpu) {
     return null;
   }
@@ -50,7 +50,7 @@ export default function HardwareInfo() {
     hardwareStatus.memory[hardwareStatus.memory.length - 1]?.value;
   const currentDiskUsage =
     hardwareStatus.disk[hardwareStatus.disk.length - 1]?.value;
-  
+
 const series = [
   {
     name: "CPU",
@@ -68,7 +68,7 @@ const series = [
     data: hardwareStatus.disk,
   },
 ];
-  
+
     return (
       <div>
         <div>

--- a/pages/help.tsx
+++ b/pages/help.tsx
@@ -15,7 +15,6 @@ import {
     SettingTwoTone,
     SlidersTwoTone,
 } from '@ant-design/icons'
-import React from 'react'
 
 interface Props { }
 

--- a/pages/help.tsx
+++ b/pages/help.tsx
@@ -2,9 +2,7 @@ import { Button, Card, Col, Divider, Result, Row } from 'antd'
 import Meta from 'antd/lib/card/Meta'
 import Title from 'antd/lib/typography/Title'
 import {
-    AlertOutlined,
     ApiTwoTone,
-    BookOutlined,
     BugTwoTone,
     CameraTwoTone,
     DatabaseTwoTone,
@@ -16,13 +14,11 @@ import {
     SlidersTwoTone,
 } from '@ant-design/icons'
 
-interface Props { }
-
-export default function Help(props: Props) {
+export default function Help() {
     const questions = [
         {
             icon: <SettingTwoTone style={{ fontSize: '24px' }} />,
-            title: "I want to configure my owncast instance",
+            title: 'I want to configure my owncast instance',
             content: (
                 <div>
                     <a href="https://owncast.online/docs/configuration/"  target="_blank" rel="noopener noreferrer"><LinkOutlined/> Learn more</a>
@@ -31,7 +27,7 @@ export default function Help(props: Props) {
         },
         {
             icon: <CameraTwoTone style={{ fontSize: '24px' }} />,
-            title: "I need help configuring my broadcasting software",
+            title: 'I need help configuring my broadcasting software',
             content: (
                 <div>
                     <a href="https://owncast.online/docs/broadcasting/"  target="_blank" rel="noopener noreferrer"><LinkOutlined/> Learn more</a>
@@ -40,7 +36,7 @@ export default function Help(props: Props) {
         },
         {
             icon: <Html5TwoTone style={{ fontSize: '24px' }} />,
-            title: "I want to embed my stream into another site",
+            title: 'I want to embed my stream into another site',
             content: (
                 <div>
                     <a href="https://owncast.online/docs/embed/"  target="_blank" rel="noopener noreferrer"><LinkOutlined/> Learn more</a>
@@ -49,7 +45,7 @@ export default function Help(props: Props) {
         },
         {
             icon: <EditTwoTone style={{ fontSize: '24px' }} />,
-            title: "I want to customize my website",
+            title: 'I want to customize my website',
             content: (
                 <div>
                     <a href="https://owncast.online/docs/website/"  target="_blank" rel="noopener noreferrer"><LinkOutlined/> Learn more</a>
@@ -58,7 +54,7 @@ export default function Help(props: Props) {
         },
         {
             icon: <SlidersTwoTone style={{ fontSize: '24px' }} />,
-            title: "I want to tweak my encoding quality or performance",
+            title: 'I want to tweak my encoding quality or performance',
             content: (
                 <div>
                     <a href="https://owncast.online/docs/encoding/"  target="_blank" rel="noopener noreferrer"><LinkOutlined/> Learn more</a>
@@ -67,7 +63,7 @@ export default function Help(props: Props) {
         },
         {
             icon: <DatabaseTwoTone style={{ fontSize: '24px' }} />,
-            title: "I want to offload my video to an external storage provider",
+            title: 'I want to offload my video to an external storage provider',
             content: (
                 <div>
                     <a href="https://owncast.online/docs/s3/"  target="_blank" rel="noopener noreferrer"><LinkOutlined/> Learn more</a>
@@ -79,37 +75,37 @@ export default function Help(props: Props) {
     const otherResources = [
         {
             icon: <BugTwoTone style={{ fontSize: '24px' }}  />,
-            title: "I found a bug",
+            title: 'I found a bug',
             content: (
                 <div>
-                    If you found a bug, then please 
+                    If you found a bug, then please
                     <a href="https://github.com/owncast/owncast/issues/new/choose" target="_blank" rel="noopener noreferrer"> let us know</a>
                 </div>
             )
         },
         {
             icon: <QuestionCircleTwoTone style={{ fontSize: '24px' }}  />,
-            title: "I have a general question",
+            title: 'I have a general question',
             content: (
                 <div>
-                    Most general questions are answered in our 
+                    Most general questions are answered in our
                     <a href="https://owncast.online/docs/faq/" target="_blank" rel="noopener noreferrer"> FAQ</a> or exist in our <a href="https://github.com/owncast/owncast/discussions">discussions</a>
                 </div>
             )
         },
         {
             icon: <ApiTwoTone style={{ fontSize: '24px' }}  />,
-            title: "I want to use the API",
+            title: 'I want to use the API',
             content: (
                 <div>
-                    You can view the API documentation for either the 
+                    You can view the API documentation for either the
                     <a href="https://owncast.online/api/latest" target="_blank" rel="noopener noreferrer">&nbsp;latest&nbsp;</a>
-                    or 
+                    or
                     <a href="https://owncast.online/api/development" target="_blank" rel="noopener noreferrer">&nbsp;development&nbsp;</a>
                     release.
                 </div>
             )
-        }   
+        }
     ]
 
     return (

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -7,13 +7,13 @@ Will display an overview with the following datasources:
 TODO: Link each overview value to the sub-page that focuses on it.
 */
 
-import React, { useState, useEffect, useContext } from "react";
-import { Skeleton, Card, Statistic } from "antd";
-import { UserOutlined, ClockCircleOutlined } from "@ant-design/icons";
-import { formatDistanceToNow, formatRelative } from "date-fns";
-import { ServerStatusContext } from "../utils/server-status-context";
-import StatisticItem from "./components/statistic"
-import LogTable from "./components/log-table";
+import { useState, useEffect, useContext } from 'react';
+import { Skeleton, Card, Statistic } from 'antd';
+import { UserOutlined, ClockCircleOutlined } from '@ant-design/icons';
+import { formatDistanceToNow, formatRelative } from 'date-fns';
+import { ServerStatusContext } from '../utils/server-status-context';
+import StatisticItem from './components/statistic'
+import LogTable from './components/log-table';
 import Offline from './offline-notice';
 
 import {
@@ -21,7 +21,7 @@ import {
   fetchData,
   FETCH_INTERVAL,
 } from "../utils/apis";
-import { formatIPAddress, isEmptyObject } from "../utils/format";
+import { formatIPAddress, isEmptyObject } from '../utils/format';
 
 function streamDetailsFormatter(streamDetails) {
   return (
@@ -77,7 +77,7 @@ export default function Home() {
   if (!broadcaster) {
     return <Offline logs={logsData} />;
   }
-  
+
   // map out settings
   const videoQualitySettings = configData?.videoSettings?.videoQualityVariants?.map((setting, index) => {
     const { audioPassthrough, videoPassthrough, audioBitrate, videoBitrate, framerate } = setting;
@@ -89,7 +89,7 @@ export default function Home() {
     const videoSetting = videoPassthrough
         ? `${streamDetails.videoBitrate || 'Unknown'} kbps, ${streamDetails.framerate} fps ${streamDetails.width} x ${streamDetails.height}`
         : `${videoBitrate || 'Unknown'} kbps, ${framerate} fps`;
-    
+
     let settingTitle = 'Outbound Stream Details';
     settingTitle = (videoQualitySettings?.length > 1) ?
       `${settingTitle} ${index + 1}` : settingTitle;
@@ -118,7 +118,7 @@ export default function Home() {
   const broadcastDate = new Date(broadcaster.time);
 
   return (
-    <div className="home-container">      
+    <div className="home-container">
       <div className="sections-container">
         <div className="section online-status-section">
           <Card title="Stream is online" type="inner">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -20,7 +20,7 @@ import {
   LOGS_WARN,
   fetchData,
   FETCH_INTERVAL,
-} from "../utils/apis";
+} from '../utils/apis';
 import { formatIPAddress, isEmptyObject } from '../utils/format';
 
 function streamDetailsFormatter(streamDetails) {
@@ -38,7 +38,7 @@ export default function Home() {
   const { broadcaster, serverConfig: configData } = serverStatusData || {};
   const { remoteAddr, streamDetails } = broadcaster || {};
 
-  const encoder = streamDetails?.encoder || "Unknown encoder";
+  const encoder = streamDetails?.encoder || 'Unknown encoder';
 
   const [logsData, setLogs] = useState([]);
   const getLogs = async () => {
@@ -46,7 +46,7 @@ export default function Home() {
       const result = await fetchData(LOGS_WARN);
       setLogs(result);
     } catch (error) {
-      console.log("==== error", error);
+      console.log('==== error', error);
     }
   };
   const getMoreStats = () => {
@@ -94,7 +94,7 @@ export default function Home() {
     settingTitle = (videoQualitySettings?.length > 1) ?
       `${settingTitle} ${index + 1}` : settingTitle;
     return (
-      <Card title={settingTitle} type="inner" key={`${settingTitle}${index}`}>
+      <Card title={settingTitle} type="inner" key={`${settingTitle}`}>
         <StatisticItem
           title="Outbound Video Stream"
           value={videoSetting}

--- a/pages/logs.tsx
+++ b/pages/logs.tsx
@@ -4,7 +4,7 @@ import LogTable from './components/log-table';
 import {
   LOGS_ALL,
   fetchData,
-} from "../utils/apis";
+} from '../utils/apis';
 
 const FETCH_INTERVAL = 5 * 1000; // 5 sec
 
@@ -16,7 +16,7 @@ export default function Logs() {
       const result = await fetchData(LOGS_ALL);
       setLogs(result);
     } catch (error) {
-      console.log("==== error", error);
+      console.log('==== error', error);
     }
   };
 

--- a/pages/logs.tsx
+++ b/pages/logs.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from "react";
-import LogTable from "./components/log-table";
+import { useState, useEffect } from 'react';
+import LogTable from './components/log-table';
 
 import {
   LOGS_ALL,
@@ -33,6 +33,5 @@ export default function Logs() {
     };
   }, []);
 
-  return <LogTable logs={logs} pageSize={20}/>;  
+  return <LogTable logs={logs} pageSize={20}/>;
 }
-

--- a/pages/offline-notice.tsx
+++ b/pages/offline-notice.tsx
@@ -1,8 +1,8 @@
 import { Result, Card } from 'antd';
 import { MessageTwoTone, QuestionCircleTwoTone, BookTwoTone, PlaySquareTwoTone } from '@ant-design/icons';
+import Link from 'next/link';
 import OwncastLogo from './components/logo'
 import LogTable from './components/log-table';
-import Link from 'next/link';
 
 const { Meta } = Card;
 
@@ -10,7 +10,7 @@ export default function Offline({ logs = [] }) {
   const data = [
     {
       icon: <BookTwoTone twoToneColor="#6f42c1" />,
-      title: "Use your broadcasting software",
+      title: 'Use your broadcasting software',
       content: (
         <div>
           <a href="https://owncast.online/docs/broadcasting/">Learn how to point your existing software to your new server and start streaming your content.</a>
@@ -19,12 +19,12 @@ export default function Offline({ logs = [] }) {
     },
     {
       icon: <MessageTwoTone twoToneColor="#0366d6" />,
-      title: "Chat is disabled",
-      content: "Chat will continue to be disabled until you begin a live stream."
+      title: 'Chat is disabled',
+      content: 'Chat will continue to be disabled until you begin a live stream.'
     },
     {
       icon: <PlaySquareTwoTone twoToneColor="#f9826c" />,
-      title: "Embed your video onto other sites",
+      title: 'Embed your video onto other sites',
       content: (
         <div>
           <a href="https://owncast.online/docs/embed">Learn how you can add your Owncast stream to other sites you control.</a>
@@ -33,7 +33,7 @@ export default function Offline({ logs = [] }) {
     },
     {
       icon: <QuestionCircleTwoTone twoToneColor="#ffd33d" />,
-      title: "Not sure what to do next?",
+      title: 'Not sure what to do next?',
       content: (
         <div>
           If you're having issues or would like to know how to customize and configure your Owncast server visit <Link href="/help">the help page.</Link>

--- a/pages/offline-notice.tsx
+++ b/pages/offline-notice.tsx
@@ -1,7 +1,7 @@
-import { Result, Card } from "antd";
+import { Result, Card } from 'antd';
 import { MessageTwoTone, QuestionCircleTwoTone, BookTwoTone, PlaySquareTwoTone } from '@ant-design/icons';
-import OwncastLogo from "./components/logo"
-import LogTable from "./components/log-table";
+import OwncastLogo from './components/logo'
+import LogTable from './components/log-table';
 import Link from 'next/link';
 
 const { Meta } = Card;

--- a/pages/storage.tsx
+++ b/pages/storage.tsx
@@ -1,5 +1,5 @@
-import React, { useContext } from "react";
-import KeyValueTable from "./components/key-value-table";
+import { useContext } from 'react';
+import KeyValueTable from './components/key-value-table';
 import { ServerStatusContext } from '../utils/server-status-context';
 import { Typography } from 'antd';
 import Link from 'next/link';

--- a/pages/storage.tsx
+++ b/pages/storage.tsx
@@ -1,8 +1,8 @@
 import { useContext } from 'react';
-import KeyValueTable from './components/key-value-table';
-import { ServerStatusContext } from '../utils/server-status-context';
 import { Typography } from 'antd';
 import Link from 'next/link';
+import KeyValueTable from './components/key-value-table';
+import { ServerStatusContext } from '../utils/server-status-context';
 
 const { Title } = Typography;
 
@@ -31,27 +31,27 @@ function Storage({ config }) {
 
   const data = [
     {
-      name: "Enabled",
+      name: 'Enabled',
       value: config.s3.enabled.toString(),
     },
     {
-      name: "Endpoint",
+      name: 'Endpoint',
       value: config.s3.endpoint,
     },
     {
-      name: "Access Key",
+      name: 'Access Key',
       value: config.s3.accessKey,
     },
     {
-      name: "Secret",
+      name: 'Secret',
       value: config.s3.secret,
     },
     {
-      name: "Bucket",
+      name: 'Bucket',
       value: config.s3.bucket,
     },
     {
-      name: "Region",
+      name: 'Region',
       value: config.s3.region,
     },
   ];

--- a/pages/update-server-config.tsx
+++ b/pages/update-server-config.tsx
@@ -15,14 +15,14 @@ function SocialHandles({ config }) {
 
   const columns = [
     {
-      title: "Platform",
-      dataIndex: "platform",
-      key: "platform",
+      title: 'Platform',
+      dataIndex: 'platform',
+      key: 'platform',
     },
     {
-      title: "URL",
-      dataIndex: "url",
-      key: "url",
+      title: 'URL',
+      dataIndex: 'url',
+      key: 'url',
       render: (url) => <a href={url}>{url}</a>
     },
   ];
@@ -53,46 +53,46 @@ function InstanceDetails({ config }) {
 
   const data = [
     {
-      name: "Server name",
+      name: 'Server name',
       value: instanceDetails.name,
     },
     {
-      name: "Title",
+      name: 'Title',
       value: instanceDetails.title,
     },
     {
-      name: "Summary",
+      name: 'Summary',
       value: instanceDetails.summary,
     },
     {
-      name: "Logo",
+      name: 'Logo',
       value: instanceDetails.logo,
     },
     {
-      name: "Tags",
-      value: instanceDetails.tags?.join(", "),
+      name: 'Tags',
+      value: instanceDetails.tags?.join(', '),
     },
     {
-      name: "NSFW",
+      name: 'NSFW',
       value: instanceDetails.nsfw?.toString(),
     },
     {
-      name: "Shows in Owncast directory",
+      name: 'Shows in Owncast directory',
       value: yp.enabled.toString(),
     },
   ];
 
   const configData = [
     {
-      name: "Stream key",
+      name: 'Stream key',
       value: streamKey,
     },
     {
-      name: "ffmpeg path",
+      name: 'ffmpeg path',
       value: ffmpegPath,
     },
     {
-      name: "Web server port",
+      name: 'Web server port',
       value: webServerPort,
     },
   ];

--- a/pages/update-server-config.tsx
+++ b/pages/update-server-config.tsx
@@ -1,7 +1,7 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { Table, Typography, Input } from 'antd';
 import { isEmptyObject } from '../utils/format';
-import KeyValueTable from "./components/key-value-table";
+import KeyValueTable from './components/key-value-table';
 import { ServerStatusContext } from '../utils/server-status-context';
 import adminStyles from '../styles/styles.module.scss';
 
@@ -50,7 +50,7 @@ function InstanceDetails({ config }) {
   }
 
   const { instanceDetails = {}, yp, streamKey, ffmpegPath, webServerPort } = config;
-  
+
   const data = [
     {
       name: "Server name",
@@ -133,9 +133,8 @@ export default function ServerConfig() {
       <InstanceDetails config={config} />
       <SocialHandles config={config} />
       <PageContent config={config} />
-      
+
       <Title level={5}>Learn more about configuring Owncast <a href="https://owncast.online/docs/configuration">by visiting the documentation.</a></Title>
     </>
-  ); 
+  );
 }
-

--- a/pages/upgrade.tsx
+++ b/pages/upgrade.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useEffect } from "react";
-import ReactMarkdown from "react-markdown";
-import { Table, Typography } from "antd";
-import { getGithubRelease } from "../utils/apis";
+import { useState, useEffect } from 'react';
+import ReactMarkdown from 'react-markdown';
+import { Table, Typography } from 'antd';
+import { getGithubRelease } from '../utils/apis';
 
 const { Title } = Typography;
 
@@ -66,4 +66,3 @@ export default function Logs() {
     </div>
   );
 }
-

--- a/pages/upgrade.tsx
+++ b/pages/upgrade.tsx
@@ -10,16 +10,16 @@ function AssetTable(assets) {
 
   const columns = [
     {
-      title: "Name",
-      dataIndex: "name",
-      key: "name",
+      title: 'Name',
+      dataIndex: 'name',
+      key: 'name',
       render: (text, entry) =>
         <a href={entry.browser_download_url}>{text}</a>,
     },
     {
-      title: "Size",
-      dataIndex: "size",
-      key: "size",
+      title: 'Size',
+      dataIndex: 'size',
+      key: 'size',
       render: (text) => (`${(text/1024/1024).toFixed(2)} MB`),
     },
   ];
@@ -30,10 +30,10 @@ function AssetTable(assets) {
 
 export default function Logs() {
   const [release, setRelease] = useState({
-    html_url: "",
-    name: "",
+    html_url: '',
+    name: '',
     created_at: null,
-    body: "",
+    body: '',
     assets: [],
 
   });
@@ -43,7 +43,7 @@ export default function Logs() {
       const result = await getGithubRelease();
       setRelease(result);
     } catch (error) {
-      console.log("==== error", error);
+      console.log('==== error', error);
     }
   };
 

--- a/pages/video-config.tsx
+++ b/pages/video-config.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import { Table, Typography } from 'antd';
 import { ServerStatusContext } from '../utils/server-status-context';
 

--- a/pages/video-config.tsx
+++ b/pages/video-config.tsx
@@ -12,63 +12,63 @@ function VideoVariants({ config }) {
 
   const videoQualityColumns = [
     {
-      title: "#",
-      dataIndex: "key",
-      key: "key"
+      title: '#',
+      dataIndex: 'key',
+      key: 'key'
     },
     {
-      title: "Video bitrate",
-      dataIndex: "videoBitrate",
-      key: "videoBitrate",
+      title: 'Video bitrate',
+      dataIndex: 'videoBitrate',
+      key: 'videoBitrate',
       render: (bitrate) =>
-        !bitrate ? "Same as source" : `${bitrate} kbps`,
+        !bitrate ? 'Same as source' : `${bitrate} kbps`,
     },
     {
-      title: "Framerate",
-      dataIndex: "framerate",
-      key: "framerate",
+      title: 'Framerate',
+      dataIndex: 'framerate',
+      key: 'framerate',
       render: (framerate) =>
-        !framerate ? "Same as source" : `${framerate} fps`,
+        !framerate ? 'Same as source' : `${framerate} fps`,
     },
     {
-      title: "Encoder preset",
-      dataIndex: "encoderPreset",
-      key: "framerate",
+      title: 'Encoder preset',
+      dataIndex: 'encoderPreset',
+      key: 'framerate',
       render: (preset) =>
-        !preset ? "n/a" : preset,
+        !preset ? 'n/a' : preset,
     },
     {
-      title: "Audio bitrate",
-      dataIndex: "audioBitrate",
-      key: "audioBitrate",
+      title: 'Audio bitrate',
+      dataIndex: 'audioBitrate',
+      key: 'audioBitrate',
       render: (bitrate) =>
-        !bitrate ? "Same as source" : `${bitrate} kbps`,
+        !bitrate ? 'Same as source' : `${bitrate} kbps`,
     },
   ];
 
   const miscVideoSettingsColumns = [
     {
-      title: "Name",
-      dataIndex: "name",
-      key: "name",
+      title: 'Name',
+      dataIndex: 'name',
+      key: 'name',
     },
     {
-      title: "Value",
-      dataIndex: "value",
-      key: "value",
+      title: 'Value',
+      dataIndex: 'value',
+      key: 'value',
     },
   ];
 
   const miscVideoSettings = [
     {
-      name: "Segment length",
+      name: 'Segment length',
       value: config.videoSettings.segmentLengthSeconds,
-      key: "segmentLength"
+      key: 'segmentLength'
     },
     {
-      name: "Number of segments",
+      name: 'Number of segments',
       value: config.videoSettings.numberOfPlaylistItems,
-      key: "numberOfSegments"
+      key: 'numberOfSegments'
     },
   ];
 
@@ -100,7 +100,7 @@ function VideoVariants({ config }) {
   );
 }
 
-export default function VideoConfig() {  
+export default function VideoConfig() {
   const serverStatusData = useContext(ServerStatusContext);
   const { serverConfig: config } = serverStatusData || {};
 
@@ -108,6 +108,5 @@ export default function VideoConfig() {
     <div>
         <VideoVariants config={config} />
     </div>
-  ); 
+  );
 }
-

--- a/pages/viewer-info.tsx
+++ b/pages/viewer-info.tsx
@@ -1,10 +1,10 @@
-import React, { useState, useEffect, useContext } from 'react';
-import { Table, Row } from "antd";
-import { formatDistanceToNow } from "date-fns";
-import { UserOutlined} from "@ant-design/icons";
-import { SortOrder } from "antd/lib/table/interface";
-import Chart from "./components/chart";
-import StatisticItem from "./components/statistic";
+import { useState, useEffect, useContext } from 'react';
+import { Table, Row } from 'antd';
+import { formatDistanceToNow } from 'date-fns';
+import { UserOutlined} from '@ant-design/icons';
+import { SortOrder } from 'antd/lib/table/interface';
+import Chart from './components/chart';
+import StatisticItem from './components/statistic';
 
 import { ServerStatusContext } from '../utils/server-status-context';
 

--- a/pages/viewer-info.tsx
+++ b/pages/viewer-info.tsx
@@ -12,7 +12,7 @@ import {
   CONNECTED_CLIENTS,
   VIEWERS_OVER_TIME,
   fetchData,
-} from "../utils/apis";
+} from '../utils/apis';
 
 const FETCH_INTERVAL = 60 * 1000; // 1 min
 
@@ -33,14 +33,14 @@ export default function ViewersOverTime() {
       const result = await fetchData(VIEWERS_OVER_TIME);
       setViewerInfo(result);
     } catch (error) {
-      console.log("==== error", error);
+      console.log('==== error', error);
     }
 
     try {
       const result = await fetchData(CONNECTED_CLIENTS);
       setClients(result);
     } catch (error) {
-      console.log("==== error", error);
+      console.log('==== error', error);
     }
   };
 
@@ -62,42 +62,42 @@ export default function ViewersOverTime() {
   // todo - check to see if broadcast active has changed. if so, start polling.
 
   if (!viewerInfo.length) {
-    return "no info";
+    return 'no info';
   }
 
   const columns = [
     {
-      title: "User name",
-      dataIndex: "username",
-      key: "username",
-      render: (username) => username || "-",
+      title: 'User name',
+      dataIndex: 'username',
+      key: 'username',
+      render: (username) => username || '-',
       sorter: (a, b) => a.username - b.username,
-      sortDirections: ["descend", "ascend"] as SortOrder[],
+      sortDirections: ['descend', 'ascend'] as SortOrder[],
     },
     {
-      title: "Messages sent",
-      dataIndex: "messageCount",
-      key: "messageCount",
+      title: 'Messages sent',
+      dataIndex: 'messageCount',
+      key: 'messageCount',
       sorter: (a, b) => a.messageCount - b.messageCount,
-      sortDirections: ["descend", "ascend"] as SortOrder[],
+      sortDirections: ['descend', 'ascend'] as SortOrder[],
     },
     {
-      title: "Connected Time",
-      dataIndex: "connectedAt",
-      key: "connectedAt",
+      title: 'Connected Time',
+      dataIndex: 'connectedAt',
+      key: 'connectedAt',
       render: (time) => formatDistanceToNow(new Date(time)),
       sorter: (a, b) => new Date(a.connectedAt).getTime() - new Date(b.connectedAt).getTime(),
-      sortDirections: ["descend", "ascend"] as SortOrder[],
+      sortDirections: ['descend', 'ascend'] as SortOrder[],
     },
     {
-      title: "User Agent",
-      dataIndex: "userAgent",
-      key: "userAgent",
+      title: 'User Agent',
+      dataIndex: 'userAgent',
+      key: 'userAgent',
     },
     {
-      title: "Location",
-      dataIndex: "geo",
-      key: "geo",
+      title: 'Location',
+      dataIndex: 'geo',
+      key: 'geo',
       render: (geo) => geo ? `${geo.regionName}, ${geo.countryCode}` : '-',
     },
   ];

--- a/utils/apis.ts
+++ b/utils/apis.ts
@@ -41,7 +41,7 @@ export const CHAT_HISTORY = `${API_LOCATION}chat/messages`;
 export const UPDATE_CHAT_MESSGAE_VIZ = `${NEXT_PUBLIC_API_HOST}api/admin/chat/updatemessagevisibility`;
 
 
-const GITHUB_RELEASE_URL = "https://api.github.com/repos/owncast/owncast/releases/latest";
+const GITHUB_RELEASE_URL = 'https://api.github.com/repos/owncast/owncast/releases/latest';
 
 interface FetchOptions {
   data?: any;
@@ -129,10 +129,10 @@ function upToDate(local, remote) {
     if (VPAT.test(local) && VPAT.test(remote)) {
         const lparts = local.split('.');
         while(lparts.length < 3)
-            lparts.push("0");
+            lparts.push('0');
         const rparts = remote.split('.');
         while (rparts.length < 3)
-            rparts.push("0");
+            rparts.push('0');
         // eslint-disable-next-line no-plusplus
         for (let i=0; i<3; i++) {
             const l = parseInt(lparts[i], 10);
@@ -143,7 +143,7 @@ function upToDate(local, remote) {
             return l > r;
         }
         return true;
-    } 
+    }
         return local >= remote;
-    
+
 }

--- a/utils/format.ts
+++ b/utils/format.ts
@@ -7,7 +7,7 @@ export function formatIPAddress(ipAddress: string): string {
   let ip = ipAddressComponents.join(':')
   ip = ip.slice(0, ip.length - 1)
   if (ip === '[::1]' || ip === '127.0.0.1') {
-    return "Localhost"
+    return 'Localhost'
   }
 
   return ip;

--- a/utils/hook-windowresize.tsx
+++ b/utils/hook-windowresize.tsx
@@ -17,15 +17,15 @@ export default function useWindowSize() {
         height: window.innerHeight,
       });
     }
-    
+
     // Add event listener
-    window.addEventListener("resize", handleResize);
-    
+    window.addEventListener('resize', handleResize);
+
     // Call handler right away so state gets updated with initial window size
     handleResize();
-    
+
     // Remove event listener on cleanup
-    return () => window.removeEventListener("resize", handleResize);
+    return () => window.removeEventListener('resize', handleResize);
   }, []); // Empty array ensures that effect is only run on mount
 
   return windowSize;

--- a/utils/server-status-context.tsx
+++ b/utils/server-status-context.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { createContext, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 import { STATUS, fetchData, FETCH_INTERVAL, SERVER_CONFIG } from './apis';
@@ -33,7 +33,7 @@ const initialServerStatusState = {
   versionNumber: '0.0.0',
 };
 
-export const ServerStatusContext = React.createContext({
+export const ServerStatusContext = createContext({
   ...initialServerStatusState,
   serverConfig: initialServerConfigState,
 });


### PR DESCRIPTION
https://github.com/reactjs/react-codemod
As of Babel 7.9.0, when using runtime: automatic in @babel/preset-react or @babel/plugin-transform-react-jsx, you will not need to explicitly import React for compiling jsx. (next supports this out of the box)
- This PR ran codemod to remove the redundant import statements. 
You can try it yourself against master by running `npx react-codemod update-react-imports`

- Also fix mixing of single and double quotes among imports. 

After refactor the page is still working. 

![image](https://user-images.githubusercontent.com/13009812/104126366-b01bb780-538e-11eb-97e5-b17b993b6161.png)
![image](https://user-images.githubusercontent.com/13009812/104126379-c32e8780-538e-11eb-9121-e619442a2532.png)
