### PR TITLE
tweaks to offline state in admin viewers page

### DIFF
--- a/pages/viewer-info.tsx
+++ b/pages/viewer-info.tsx
@@ -96,24 +96,26 @@ export default function ViewersOverTime() {
   return (
     <div>
       <Row gutter={[16, 16]} justify="space-around">
+        {online && (
+          <StatisticItem
+            title="Current viewers"
+            value={viewerCount.toString()}
+            prefix={<UserOutlined />}
+          />
+        )}
         <StatisticItem
-          title="Current viewers"
-          value={viewerCount.toString()}
-          prefix={<UserOutlined />}
-        />
-        <StatisticItem
-          title="Peak viewers this session"
+          title={online ? 'Max viewers this session' : 'Max viewers last session'}
           value={sessionPeakViewerCount.toString()}
           prefix={<UserOutlined />}
         />
         <StatisticItem
-          title="Peak viewers overall"
+          title="All-time max viewers"
           value={overallPeakViewerCount.toString()}
           prefix={<UserOutlined />}
         />
       </Row>
       <Chart title="Viewers" data={viewerInfo} color="#2087E2" unit="" />
-      <Table dataSource={clients} columns={columns} rowKey={row => row.clientID} />
+      {online && <Table dataSource={clients} columns={columns} rowKey={row => row.clientID} />}
     </div>
   );
 }


### PR DESCRIPTION
If stream is offline, hide current viewers statistic and viewers table.
Also, change wording for describing max viewers.

closes https://github.com/owncast/owncast/issues/662