### PR TITLE
Don't overwrite logs state when server goes offline 

### DIFF
--- a/pages/logs.tsx
+++ b/pages/logs.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useState } from 'react';
 import LogTable from '../components/log-table';
 import { fetchData, LOGS_ALL } from '../utils/apis';
 
-
 const FETCH_INTERVAL = 5 * 1000; // 5 sec
 
 export default function Logs() {
@@ -14,7 +13,7 @@ export default function Logs() {
     try {
       const result = await fetchData(LOGS_ALL);
 
-      if(result.length !== 0) {
+      if (result.length !== 0) {
         setLogs(result);
       }
 
@@ -38,8 +37,17 @@ export default function Logs() {
     };
   }, []);
 
-  return <>
-    {showConnectionError && <Alert message="Unable to load logs from the Owncast server." type="warning" showIcon style={{marginBottom: "1rem"}} />}
-    <LogTable logs={logs} pageSize={20} />
-  </>;
+  return (
+    <>
+      {showConnectionError && (
+        <Alert
+          message="Unable to load logs from the Owncast server."
+          type="warning"
+          showIcon
+          style={{ marginBottom: '1rem' }}
+        />
+      )}
+      <LogTable logs={logs} pageSize={20} />
+    </>
+  );
 }

--- a/pages/logs.tsx
+++ b/pages/logs.tsx
@@ -1,18 +1,26 @@
-import React, { useState, useEffect } from 'react';
+import { Alert } from 'antd';
+import React, { useEffect, useState } from 'react';
 import LogTable from '../components/log-table';
+import { fetchData, LOGS_ALL } from '../utils/apis';
 
-import { LOGS_ALL, fetchData } from '../utils/apis';
 
 const FETCH_INTERVAL = 5 * 1000; // 5 sec
 
 export default function Logs() {
   const [logs, setLogs] = useState([]);
+  const [showConnectionError, setShowConnctionError] = useState<boolean>(false);
 
   const getInfo = async () => {
     try {
       const result = await fetchData(LOGS_ALL);
-      setLogs(result);
+
+      if(result.length !== 0) {
+        setLogs(result);
+      }
+
+      setShowConnctionError(false);
     } catch (error) {
+      setShowConnctionError(true);
       console.log('==== error', error);
     }
   };
@@ -30,5 +38,8 @@ export default function Logs() {
     };
   }, []);
 
-  return <LogTable logs={logs} pageSize={20} />;
+  return <>
+    {showConnectionError && <Alert message="Unable to load logs from the Owncast server." type="warning" showIcon style={{marginBottom: "1rem"}} />}
+    <LogTable logs={logs} pageSize={20} />
+  </>;
 }

--- a/utils/apis.ts
+++ b/utils/apis.ts
@@ -105,9 +105,9 @@ export async function fetchData(url: string, options?: FetchOptions) {
     }
     return json;
   } catch (error) {
-    return error;
+    // return error;
     // console.log(error)
-    // throw new Error(error)
+    throw new Error(error)
   }
   return {};
 }

--- a/utils/apis.ts
+++ b/utils/apis.ts
@@ -107,9 +107,8 @@ export async function fetchData(url: string, options?: FetchOptions) {
   } catch (error) {
     // return error;
     // console.log(error)
-    throw new Error(error)
+    throw new Error(error);
   }
-  return {};
 }
 
 export async function getGithubRelease() {


### PR DESCRIPTION
Instead, show a alert box. This changes `fetchData` to throw errors again, I'm not sure what the implications are right now.

Fixes https://github.com/owncast/owncast/issues/434