### PR TITLE
Don't allow people to set their instance name to an empty string (or only whitespace)

### DIFF
--- a/components/config/form-textfield-with-submit.tsx
+++ b/components/config/form-textfield-with-submit.tsx
@@ -42,6 +42,7 @@ export default function TextFieldWithSubmit(props: TextFieldWithSubmitProps) {
     configPath = '',
     initialValue,
     useTrim,
+    useTrimLead,
     ...textFieldProps // rest of props
   } = props;
 
@@ -73,7 +74,7 @@ export default function TextFieldWithSubmit(props: TextFieldWithSubmitProps) {
     if (onChange) {
       onChange({
         fieldName: changedFieldName,
-        value: useTrim ? changedValue.trim() : changedValue,
+        value: useTrim ? changedValue.trim() : useTrimLead ? changedValue.replace(/^\s+/g,'') : changedValue,
       });
     }
   };

--- a/components/config/form-textfield.tsx
+++ b/components/config/form-textfield.tsx
@@ -29,6 +29,7 @@ export interface TextFieldProps {
   tip?: string;
   type?: string;
   useTrim?: boolean;
+  useTrimLead?: boolean;
   value?: string | number;
   onBlur?: FieldUpdaterFunc;
   onChange?: FieldUpdaterFunc;

--- a/utils/config-constants.tsx
+++ b/utils/config-constants.tsx
@@ -57,6 +57,7 @@ export const TEXTFIELD_PROPS_SERVER_NAME = {
   label: 'Name',
   tip: 'The name of your Owncast server',
   required: true,
+  useTrimLead: true,
 };
 export const TEXTFIELD_PROPS_STREAM_TITLE = {
   apiPath: API_STREAM_TITLE,

--- a/utils/config-constants.tsx
+++ b/utils/config-constants.tsx
@@ -56,6 +56,7 @@ export const TEXTFIELD_PROPS_SERVER_NAME = {
   placeholder: 'Owncast site name', // like "gothland"
   label: 'Name',
   tip: 'The name of your Owncast server',
+  required: true,
 };
 export const TEXTFIELD_PROPS_STREAM_TITLE = {
   apiPath: API_STREAM_TITLE,


### PR DESCRIPTION
"required" prevents empty strings and "useTrimLead" (trimming the lead space) prevents the space-only names.

closes owncast/owncast#967