### PR TITLE
Override admin chat message moderation UI selected state bg color

### DIFF
--- a/styles/ant-overrides.scss
+++ b/styles/ant-overrides.scss
@@ -320,6 +320,9 @@ textarea.ant-input {
 .ant-table-tbody > tr.ant-table-row:hover > td {
   background-color: var(--gray-dark);
 }
+.ant-table-tbody > tr.ant-table-row-selected > td {
+  background: var(--white-25);
+}
 
 .ant-empty {
   color: var(--white-75);


### PR DESCRIPTION
Here's something more readable.


![image](https://user-images.githubusercontent.com/39205857/126046310-1651276d-5f01-4e4c-935c-8dd8b7366bd4.png)
closes owncast/owncast#1120
