### PR TITLE
Fixes and enhancements to the client table.

### DIFF
--- a/components/client-table.tsx
+++ b/components/client-table.tsx
@@ -38,7 +38,7 @@ export default function ClientTable({ data }: ClientTableProps) {
           />
         </div>
       ),
-      onFilter: (value: string, record: Client) => record.user.displayName.startsWith(value),
+      onFilter: (value: string, record: Client) => record.user.displayName.includes(value),
       sortDirections: ['descend', 'ascend'] as SortOrder[],
     },
     {

--- a/components/client-table.tsx
+++ b/components/client-table.tsx
@@ -1,6 +1,7 @@
-import { Table } from 'antd';
-import { SortOrder } from 'antd/lib/table/interface';
+import { Input, Table } from 'antd';
+import { FilterDropdownProps, SortOrder } from 'antd/lib/table/interface';
 import { ColumnsType } from 'antd/es/table';
+import { SearchOutlined } from '@ant-design/icons';
 import { formatDistanceToNow } from 'date-fns';
 import { Client } from '../types/chat';
 import UserPopover from './user-popover';
@@ -23,6 +24,24 @@ export default function ClientTable({ data }: ClientTableProps) {
         );
       },
       sorter: (a: any, b: any) => b.user.displayName.localeCompare(a.user.displayName),
+      filterIcon: () => <SearchOutlined />,
+      filterDropdown: ({
+        setSelectedKeys,
+        selectedKeys,
+        confirm,
+      }: FilterDropdownProps) => (
+        <div style={{ padding: 8 }}>
+          <Input
+            placeholder="Search display names..."
+            value={selectedKeys[0]}
+            onChange={e => {
+              setSelectedKeys(e.target.value ? [e.target.value] : []);
+              confirm({ closeDropdown: false });
+            }}
+          />
+        </div>
+      ),
+      onFilter: (value: string, record: Client) => record.user.displayName.startsWith(value),
       sortDirections: ['descend', 'ascend'] as SortOrder[],
     },
     {

--- a/components/client-table.tsx
+++ b/components/client-table.tsx
@@ -24,12 +24,9 @@ export default function ClientTable({ data }: ClientTableProps) {
         );
       },
       sorter: (a: any, b: any) => b.user.displayName.localeCompare(a.user.displayName),
-      filterIcon: () => <SearchOutlined />,
-      filterDropdown: ({
-        setSelectedKeys,
-        selectedKeys,
-        confirm,
-      }: FilterDropdownProps) => (
+      filterIcon: <SearchOutlined />,
+      // eslint-disable-next-line react/no-unstable-nested-components
+      filterDropdown: ({ setSelectedKeys, selectedKeys, confirm }: FilterDropdownProps) => (
         <div style={{ padding: 8 }}>
           <Input
             placeholder="Search display names..."

--- a/components/client-table.tsx
+++ b/components/client-table.tsx
@@ -22,7 +22,7 @@ export default function ClientTable({ data }: ClientTableProps) {
           </UserPopover>
         );
       },
-      sorter: (a: any, b: any) => a.user.displayName - b.user.displayName,
+      sorter: (a: any, b: any) => b.user.displayName.localeCompare(a.user.displayName),
       sortDirections: ['descend', 'ascend'] as SortOrder[],
     },
     {
@@ -42,7 +42,7 @@ export default function ClientTable({ data }: ClientTableProps) {
       defaultSortOrder: 'ascend',
       render: (time: Date) => formatDistanceToNow(new Date(time)),
       sorter: (a: any, b: any) =>
-        new Date(a.connectedAt).getTime() - new Date(b.connectedAt).getTime(),
+        new Date(b.connectedAt).getTime() - new Date(a.connectedAt).getTime(),
       sortDirections: ['descend', 'ascend'] as SortOrder[],
     },
     {

--- a/styles/ant-overrides.scss
+++ b/styles/ant-overrides.scss
@@ -308,6 +308,7 @@ textarea.ant-input {
 
 // ANT TABLE
 .ant-table-thead > tr > th,
+.ant-table-filter-dropdown,
 .ant-table-small .ant-table-thead > tr > th {
   transition-duration: var(--ant-transition-duration);
   background-color: var(--purple-dark);
@@ -349,7 +350,8 @@ textarea.ant-input {
     background-color: var(--textfield-border);
   }
 }
-.ant-table-thead th.ant-table-column-sort {
+.ant-table-thead th.ant-table-column-sort,
+.ant-dropdown-trigger.active {
   background-color: var(--owncast-purple-25);
   opacity: 0.75;
 }


### PR DESCRIPTION
Currently, the client table does not properly sort display names, and the connected time is reversed (ie. ascending sort shows descending). For example:

**Connected Time**

<img width="227" alt="image" src="https://user-images.githubusercontent.com/52957110/164882550-2c2c3b41-749a-4f4e-8fbd-d74ce1e30646.png">
<img width="227" alt="image" src="https://user-images.githubusercontent.com/52957110/164882573-b4e00f61-40f7-42d8-bafc-a0ef78e12c26.png">

**Display Name**

<img width="207" alt="image" src="https://user-images.githubusercontent.com/52957110/164882579-eda57dff-2717-4931-b07c-9fd16750b716.png">
<img width="203" alt="image" src="https://user-images.githubusercontent.com/52957110/164882581-6bb65fc8-9492-45ad-a913-2d55359af55c.png">

The changes in this PR fixes the sort:

**Connected Time**

<img width="219" alt="image" src="https://user-images.githubusercontent.com/52957110/164882614-8af0608a-4664-4ad5-97e1-e7e0e1dfe1d4.png">
<img width="222" alt="image" src="https://user-images.githubusercontent.com/52957110/164882623-0c79689e-3d6a-4802-b362-6c21cdcc4c23.png">

**Display Name**

<img width="235" alt="image" src="https://user-images.githubusercontent.com/52957110/164882627-4f59eb0b-b390-43e8-b567-b0b8f514a8be.png">
<img width="229" alt="image" src="https://user-images.githubusercontent.com/52957110/164882631-b4d4c703-e3b4-4096-8914-60f299d67c7d.png">

## Searching Usernames

I also added a search dropdown since the list quickly becomes unwieldly when there are too many viewers.

<img width="232" alt="image" src="https://user-images.githubusercontent.com/52957110/164882803-f48ce08d-5c08-499c-ab1a-a4deb874e8c0.png">
<img width="234" alt="image" src="https://user-images.githubusercontent.com/52957110/164882811-06d9d901-2f46-4062-b242-39ade8c54c79.png">

Indicator when search filter is enabled:

<img width="239" alt="image" src="https://user-images.githubusercontent.com/52957110/164882818-ec12b56d-eb0a-4347-ae35-abcc0278849c.png">

EDIT: I also disabled the `react/no-unstable-nested-components` [rule](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unstable-nested-components.md) here since the input component should be fine as an unstable component here, but let me know if you'd like me to extract it out into a component. 