### PR TITLE
Generate proper StatusStates for errors from backend.

### DIFF
--- a/pages/config-chat.tsx
+++ b/pages/config-chat.tsx
@@ -29,8 +29,8 @@ import { ServerStatusContext } from '../utils/server-status-context';
 export default function ConfigChat() {
   const { Title } = Typography;
   const [formDataValues, setFormDataValues] = useState(null);
-  const [forbiddenUsernameSaveState, setForbiddenUsernameSaveState] = useState(null);
-  const [suggestedUsernameSaveState, setSuggestedUsernameSaveState] = useState(null);
+  const [forbiddenUsernameSaveState, setForbiddenUsernameSaveState] = useState<StatusState>(null);
+  const [suggestedUsernameSaveState, setSuggestedUsernameSaveState] = useState<StatusState>(null);
   const serverStatusData = useContext(ServerStatusContext);
   const { serverConfig, setFieldInConfigState } = serverStatusData || {};
 
@@ -76,7 +76,7 @@ export default function ConfigChat() {
           fieldName: 'forbiddenUsernames',
           value: formDataValues.forbiddenUsernames,
         });
-        setForbiddenUsernameSaveState(STATUS_SUCCESS);
+        setForbiddenUsernameSaveState(createInputStatus(STATUS_SUCCESS));
         setTimeout(resetForbiddenUsernameState, RESET_TIMEOUT);
       },
       onError: (message: string) => {
@@ -113,7 +113,7 @@ export default function ConfigChat() {
           fieldName: 'suggestedUsernames',
           value: formDataValues.suggestedUsernames,
         });
-        setSuggestedUsernameSaveState(STATUS_SUCCESS);
+        setSuggestedUsernameSaveState(createInputStatus(STATUS_SUCCESS));
         setTimeout(resetSuggestedUsernameState, RESET_TIMEOUT);
       },
       onError: (message: string) => {
@@ -200,7 +200,7 @@ export default function ConfigChat() {
           values={formDataValues.forbiddenUsernames}
           handleDeleteIndex={handleDeleteForbiddenUsernameIndex}
           handleCreateString={handleCreateForbiddenUsername}
-          submitStatus={createInputStatus(forbiddenUsernameSaveState)}
+          submitStatus={forbiddenUsernameSaveState}
         />
         <br />
         <br />
@@ -211,7 +211,7 @@ export default function ConfigChat() {
           values={formDataValues.suggestedUsernames}
           handleDeleteIndex={handleDeleteSuggestedUsernameIndex}
           handleCreateString={handleCreateSuggestedUsername}
-          submitStatus={createInputStatus(suggestedUsernameSaveState)}
+          submitStatus={suggestedUsernameSaveState}
           continuousStatusMessage={getSuggestedUsernamesLimitWarning(
             formDataValues.suggestedUsernames.length,
           )}


### PR DESCRIPTION
Currently, the error messages from the backend don't show up on the forbidden usernames and default username fields because they get wrapped as a `StatusState`, which the final render tries to wrap again in a `StatusState` with `createInputStatus`, returning a `null`. This results in the error messages not showing up in the UI.

While this isn't a problem for the most part since the backend doesn't have too many error conditions on this path, the lack of visibility in the backend's errors make it less obvious if additional features (like regex usernames) gets added to this endpoint. For example, I came across this because I wanted to enhance the forbidden usernames field to a list of regexes rather than exact match strings.

This change allows those error messages to show up in the UI:

<img width="398" alt="image" src="https://user-images.githubusercontent.com/52957110/164937050-bcb37e7e-ffe4-4f38-99fe-8ae55e0126fd.png">

As an aside, errors on the backend also result in an inconsistent frontend state (ie. the rendered list will have the rejected input, which requires deleting the input or refreshing the page to resolve). I didn't make any changes to this behaviour as it's a bit higher touch, but let me know if that's behaviour you'd like corrected. 